### PR TITLE
fix(config): browser support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "module": "commonjs",
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
The project that are importing icc-api doesn't have to pass it into webpack (babel). The 'dist' folder must be usable as is.