### PR TITLE
[MS-3745] Do not drop ArrayBuffer/UInt8Array objects from the JSON content

### DIFF
--- a/api/XHR.ts
+++ b/api/XHR.ts
@@ -110,7 +110,11 @@ export namespace XHR {
           ? {
               body:
                 (!contentType || contentType.data) === "application/json"
-                  ? JSON.stringify(data)
+                  ? JSON.stringify(data, (k, v) => {
+                      return v instanceof ArrayBuffer || v instanceof Uint8Array
+                        ? btoa(new Uint8Array(v).reduce((d, b) => d + String.fromCharCode(b), ""))
+                        : v
+                    })
                   : data
             }
           : {}


### PR DESCRIPTION
Antoine Duchateau, your suggested fix worked very well. `Document#content` is now correctly deserialised by the `freehealth-connector`.

Here is a PR so you can include your fix ASAP.